### PR TITLE
Removed console.log from prefix command

### DIFF
--- a/commands/System/prefix.js
+++ b/commands/System/prefix.js
@@ -1,5 +1,4 @@
 exports.run = (client, msg, [pref]) => {
-    console.log(pref);
     if (!pref) {
         msg.reply(`Your prefix is ${client.config.prefix}`);
         } else {


### PR DESCRIPTION
Removed console.log(pref) as it was used in a dev environment to determine if the prefix was being logged.
