### PR TITLE
deleteCommandTrigger Inhibitor

### DIFF
--- a/inhibitors/deleteCommand.js
+++ b/inhibitors/deleteCommand.js
@@ -1,0 +1,20 @@
+exports.conf = {
+  enabled: true,
+  spamProtection: false
+};
+
+exports.run = (client, msg, cmd) => {
+  return new Promise((resolve, reject) => {
+    let conf = msg.guildConf;
+    if (!conf.delete) {
+      client.funcs.confs.addKey("deleteCommand", false);
+      conf = msg.guildConf;
+    }
+    if (!cmd.conf.ignoreDelete && conf.deleteCommand === true) {
+      msg.delete();
+      resolve();
+    } else {
+      resolve();
+    }
+  });
+};

--- a/inhibitors/deleteCommand.js
+++ b/inhibitors/deleteCommand.js
@@ -2,18 +2,17 @@ exports.conf = {
   enabled: true,
   spamProtection: false
 };
+exports.init = (client) => {
+  if (!client.funcs.confs.hasKey("deleteCommand")) {
+    client.funcs.confs.addKey("deleteCommand", false);
+  }
+}
 
 exports.run = (client, msg, cmd) => {
   return new Promise((resolve, reject) => {
-    let conf = msg.guildConf;
-    if (!conf.delete) {
-      client.funcs.confs.addKey("deleteCommand", false);
-      conf = msg.guildConf;
-    }
-    if (!cmd.conf.ignoreDelete && conf.deleteCommand === true) {
+    if (!cmd.conf.ignoreDelete && msg.guildConf.deleteCommand === true) {
       msg.delete();
-      resolve();
-    } else {
+    }
       resolve();
     }
   });

--- a/inhibitors/deleteCommand.js
+++ b/inhibitors/deleteCommand.js
@@ -14,6 +14,5 @@ exports.run = (client, msg, cmd) => {
       msg.delete();
     }
       resolve();
-    }
   });
 };


### PR DESCRIPTION
Allows you to specify what servers you want commands deleted on. Just change it to true if you want all commands deleted or false if you want them to appear in chat.
You can overwrite a command delete by adding this to the commands conf object.
`ignoreDelete: true`