### PR TITLE
Fix for sqlite dataProvider

### DIFF
--- a/dataProviders/sqlite.js
+++ b/dataProviders/sqlite.js
@@ -87,7 +87,11 @@ exports.getAll = (client, table) =>
 exports.insert = (client, table, keys, values) =>
    new Promise((resolve, reject) => {
      if (!schemaCache.has(table)) reject("Table not found in schema cache");
-     const schema = schemaCache.get(table);
+     try {
+       const schema = JSON.parse(schemaCache.get(table));
+     } catch (e) {
+       reject("Error parsing schema cache data"); 
+     }
      client.funcs.validateData(schema, keys, values); // automatically throws error
      const insertValues = schema.map((field, index) => dataSchema[field.type].insert(values[index]));
      const questionMarks = schema.map(() => "?").join(", ");

--- a/dataProviders/sqlite.js
+++ b/dataProviders/sqlite.js
@@ -113,7 +113,11 @@ exports.has = (client, table, key, value) =>
 exports.update = (client, table, keys, values, whereKey, whereValue) =>
    new Promise((resolve, reject) => {
      if (!schemaCache.has(table)) reject("Table not found in schema cache");
-     const schema = schemaCache.get(table);
+     try {
+       const schema = JSON.parse(schemaCache.get(table));
+     } catch (e) {
+       reject("Error parsing schema cache data"); 
+     }
      const filtered = schema.filter(f => keys.includes(f.name));
      client.funcs.validateData(schema, keys, values);
      const inserts = filtered.map((field, index) => `${field.name} = ${dataSchema[field.type].insert(values[index])}`);

--- a/dataProviders/sqlite.js
+++ b/dataProviders/sqlite.js
@@ -87,8 +87,9 @@ exports.getAll = (client, table) =>
 exports.insert = (client, table, keys, values) =>
    new Promise((resolve, reject) => {
      if (!schemaCache.has(table)) reject("Table not found in schema cache");
+     let schema = null;
      try {
-       const schema = JSON.parse(schemaCache.get(table));
+       schema = JSON.parse(schemaCache.get(table));
      } catch (e) {
        reject("Error parsing schema cache data"); 
      }
@@ -113,8 +114,9 @@ exports.has = (client, table, key, value) =>
 exports.update = (client, table, keys, values, whereKey, whereValue) =>
    new Promise((resolve, reject) => {
      if (!schemaCache.has(table)) reject("Table not found in schema cache");
+     let schema = null;
      try {
-       const schema = JSON.parse(schemaCache.get(table));
+       schema = JSON.parse(schemaCache.get(table));
      } catch (e) {
        reject("Error parsing schema cache data"); 
      }


### PR DESCRIPTION
This change fixes "TypeError: data.find is not a function" from validateData(). Apparently schemaCache returns a string instead of an Array so it has to be parsed first.