### PR TITLE
commandCooldown inhibitor

### DIFF
--- a/inhibitors/commandCooldown.js
+++ b/inhibitors/commandCooldown.js
@@ -1,0 +1,69 @@
+/**
+ * Created by Bastien on 17/01/2017.
+ */
+// Add this to the export.conf of any command to implement a cooldown per command
+//
+// cooldowns: {
+//     //Is the cooldown per player or guild
+//     scope: "guild",
+//     time: 15000
+// }
+
+const cooldowns = new Map();
+
+exports.conf = {
+    enabled: true,
+    spamProtection: true
+};
+
+exports.run = (client, msg, cmd) => {
+    return new Promise((resolve, reject) => {
+        const commandName = cmd.help.name;
+
+        //default behaviour
+        //change this to msg.channel.id or msg.guild.id to override default behaviour
+        let id = msg.author.id;
+
+        const standardCooldown = 1000;
+        let commandCooldown = standardCooldown;
+
+        //Override default behaviour if command.conf has cooldown variable
+        if(cmd.conf.cooldown) {
+            if(cmd.conf.cooldown.scope == "guild") {
+                id = msg.guild.id;
+            }
+
+            commandCooldown = cmd.conf.cooldown.time;
+        }
+        let entry = false;
+
+        if (!cooldowns.get(id)) cooldowns.set(id, {});
+
+        if(!cooldowns.get(id)[commandName]) cooldowns.get(id)[commandName] = createTimeOut();
+        else entry = true;
+
+        if (entry && commandCooldown != standardCooldown) {
+            let message = 'Please wait ' + commandCooldown/1000 + ' second(s) between !' +
+                commandName + ' commands.';
+
+            if(id == msg.guild.id) message += '\nThe cooldown for this command is shared across the guild.';
+
+            msg.channel.sendCode('asciidoc', message);
+        }
+
+        function createTimeOut() {
+            return setTimeout(() => {
+                let userCooldownBooleans = cooldowns.get(id);
+                delete userCooldownBooleans[commandName];
+
+                //delete key in map when its value is empty, just to keep the map clear
+                if (Object.keys(userCooldownBooleans).length === 0) {
+                    cooldowns.delete(id);
+                }
+            }, commandCooldown);
+        }
+
+        if (entry) reject();
+        else resolve();
+    });
+};

--- a/inhibitors/commandCooldown.js
+++ b/inhibitors/commandCooldown.js
@@ -1,6 +1,3 @@
-/**
- * Created by Bastien on 17/01/2017.
- */
 // Add this to the export.conf of any command to implement a cooldown per command
 //
 // cooldowns: {
@@ -12,7 +9,7 @@
 const cooldowns = new Map();
 
 exports.conf = {
-    enabled: true,
+    enabled: false,
     spamProtection: true
 };
 

--- a/inhibitors/commandSlowMode.js
+++ b/inhibitors/commandSlowMode.js
@@ -3,7 +3,7 @@ const timers = [];
 const ratelimit = 1250;
 
 exports.conf = {
-  enabled: false,
+  enabled: true,
   spamProtection: true
 };
 

--- a/inhibitors/commandSlowMode.js
+++ b/inhibitors/commandSlowMode.js
@@ -3,7 +3,7 @@ const timers = [];
 const ratelimit = 1250;
 
 exports.conf = {
-  enabled: true,
+  enabled: false,
   spamProtection: true
 };
 

--- a/inhibitors/index.md
+++ b/inhibitors/index.md
@@ -2,4 +2,4 @@ Inhibitor | Description
 ----------|-------------
 deleteCommand.js | Deletes every message that is a command. Keeps your spam down to a minimum.
 commandSlowMode.js | Ratelimits commands from being executed if spammed.
-commandCooldown.js | Ability to put a cooldown on specific commands per player, channel or guild.
+commandCooldown.js | Ability to put a cooldown on specific commands per player, channel or guild, disabled by default.

--- a/inhibitors/index.md
+++ b/inhibitors/index.md
@@ -2,3 +2,4 @@ Inhibitor | Description
 ----------|-------------
 deleteCommand.js | Deletes every message that is a command. Keeps your spam down to a minimum.
 commandSlowMode.js | Ratelimits commands from being executed if spammed.
+commandCooldown.js | Ability to put a cooldown on specific commands per player, channel or guild.


### PR DESCRIPTION
Overrides the usage of commandSlowMode a bit (that's why it's disabled by default);

Puts a cooldown per command, this cooldown can be user specific or guild-wide. Default is 1s. A message is shown when a command has a cooldown different from the default cooldown.