### PR TITLE
hierarchyCheck function

### DIFF
--- a/functions/hierarchyCheck.js
+++ b/functions/hierarchyCheck.js
@@ -3,7 +3,6 @@ Check if user is higher in guild's role hierarchy
 ...Basically an easy way to stop mods from performing actions on admins, etc
 
     Usage:
-        - client scope
         - executor is the user object of the user executing the moderation command
         - target is the user object of the user the moderation command is affecting
         - guild is the guild object of the guild the command is being executed in
@@ -11,23 +10,14 @@ Check if user is higher in guild's role hierarchy
         - boolean true if executor is higher
         - boolean false if executor is lower or equal
         - boolean false if either user isn't in the guild
+**/
 
-        **/
+const func = async (executor, target, guild = null) => {
+  if (guild) {
+    const executorMember = await guild.fetchMember(executor);
+    const targetMember = await guild.fetchMember(target);
 
-const func = async (client, executor, target, guild = null) => {
-  try {
-      if (guild) {
-          const executorMember = await guild.fetchMember(executor);
-          const targetMember = await guild.fetchMember(target);
-
-          if (executorMember.highestRole.position > targetMember.highestRole.position) {
-              return true;
-          }
-      }
-  } catch (err) {
-      client.emit("log", err, "error");
-      client.emit("log", "Failed to fetch guildMember(s). Probably at least one isn't in this guild?", "error");
-      return false;
+    return executorMember.highestRole.position > targetMember.highestRole.position;
   }
   return false;
 };

--- a/functions/hierarchyCheck.js
+++ b/functions/hierarchyCheck.js
@@ -7,42 +7,38 @@ Check if user is higher in guild's role hierarchy
         - executor is the user object of the user executing the moderation command
         - target is the user object of the user the moderation command is affecting
         - guild is the guild object of the guild the command is being executed in
-    
     Returns:
         - boolean true if executor is higher
         - boolean false if executor is lower or equal
         - boolean false if either user isn't in the guild
 
-**/
+        **/
 
 const func = async (client, executor, target, guild = null) => {
-    try{
-        if (guild) {
-            let executorMember = await guild.fetchMember(executor);
-            let targetMember = await guild.fetchMember(target);
-            
-            if(executorMember.highestRole.position > targetMember.highestRole.position){
-                    return true;
-                } else {
-                    return false;
-                }
-            }
-    }catch(err){
-        client.emit("log", err, "error");
-        client.emit("log", "Failed to fetch guildMember(s). Probably at least one isn't in this guild?", "error");
-        return false;
-    }
+  try {
+      if (guild) {
+          const executorMember = await guild.fetchMember(executor);
+          const targetMember = await guild.fetchMember(target);
 
-
-}
-
+          if (executorMember.highestRole.position > targetMember.highestRole.position) {
+              return true;
+          }
+      }
+  } catch (err) {
+      client.emit("log", err, "error");
+      client.emit("log", "Failed to fetch guildMember(s). Probably at least one isn't in this guild?", "error");
+      return false;
+  }
+  return false;
+};
 
 
 func.conf = { requiredModules: [] };
+
 func.help = {
-    name: "hierarchyCheck",
-    type: "functions",
-    description: "Checks to see that command executor is higher on guild's hierarchy than command target.",
+  name: "hierarchyCheck",
+  type: "functions",
+  description: "Checks to see that command executor is higher on guild's hierarchy than command target.",
 };
 
 module.exports = func;

--- a/functions/hierarchyCheck.js
+++ b/functions/hierarchyCheck.js
@@ -2,7 +2,8 @@
 Check if user is higher in guild's role hierarchy
 ...Basically an easy way to stop mods from performing actions on admins, etc
 
-    Usage: 
+    Usage:
+        - client scope
         - executor is the user object of the user executing the moderation command
         - target is the user object of the user the moderation command is affecting
         - guild is the guild object of the guild the command is being executed in
@@ -10,44 +11,38 @@ Check if user is higher in guild's role hierarchy
     Returns:
         - boolean true if executor is higher
         - boolean false if executor is lower or equal
+        - boolean false if either user isn't in the guild
 
 **/
 
-const func = function(executor, target, guild = null) {
-    return new Promise((resolve, reject) => {
+const func = async (client, executor, target, guild = null) => {
+    try{
         if (guild) {
-            guild.fetchMember(executor)
-            .then((executorGM) => {
-                guild.fetchMember(target)
-                .then((targetGM) => {
-                    
-                    if(executorGM.highestRole.position > targetGM.highestRole.position){
-                        resolve(true);
-                    } else {
-                        resolve(false);
-                    }
+            let executorMember = await guild.fetchMember(executor);
+            let targetMember = await guild.fetchMember(target);
+            
+            if(executorMember.highestRole.position > targetMember.highestRole.position){
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+    }catch(err){
+        client.emit("log", err, "error");
+        client.emit("log", "Failed to fetch guildMember(s). Probably at least one isn't in this guild?", "error");
+        return false;
+    }
 
-                    })
-                .catch((err) => {
-                    client.emit("log", err, "error");
-                });
-            })
-            .catch((err) => {
-                client.emit("log", err, "error");
-            });
 
-        } else {
-            resolve(false);
-        }
-    });
+}
 
-};
+
 
 func.conf = { requiredModules: [] };
 func.help = {
-	name: "hierarchyCheck",
-	type: "functions",
-	description: "Checks to see that command executor is higher on guild's hierarchy than command target.",
+    name: "hierarchyCheck",
+    type: "functions",
+    description: "Checks to see that command executor is higher on guild's hierarchy than command target.",
 };
 
 module.exports = func;

--- a/functions/hierarchyCheck.js
+++ b/functions/hierarchyCheck.js
@@ -1,0 +1,53 @@
+/**
+Check if user is higher in guild's role hierarchy
+...Basically an easy way to stop mods from performing actions on admins, etc
+
+    Usage: 
+        - executor is the user object of the user executing the moderation command
+        - target is the user object of the user the moderation command is affecting
+        - guild is the guild object of the guild the command is being executed in
+    
+    Returns:
+        - boolean true if executor is higher
+        - boolean false if executor is lower or equal
+
+**/
+
+const func = function(executor, target, guild = null) {
+    return new Promise((resolve, reject) => {
+        if (guild) {
+            guild.fetchMember(executor)
+            .then((executorGM) => {
+                guild.fetchMember(target)
+                .then((targetGM) => {
+                    
+                    if(executorGM.highestRole.position > targetGM.highestRole.position){
+                        resolve(true);
+                    } else {
+                        resolve(false);
+                    }
+
+                    })
+                .catch((err) => {
+                    client.emit("log", err, "error");
+                });
+            })
+            .catch((err) => {
+                client.emit("log", err, "error");
+            });
+
+        } else {
+            resolve(false);
+        }
+    });
+
+};
+
+func.conf = { requiredModules: [] };
+func.help = {
+	name: "hierarchyCheck",
+	type: "functions",
+	description: "Checks to see that command executor is higher on guild's hierarchy than command target.",
+};
+
+module.exports = func;

--- a/functions/hierarchyCheck.js
+++ b/functions/hierarchyCheck.js
@@ -3,22 +3,24 @@ Check if user is higher in guild's role hierarchy
 ...Basically an easy way to stop mods from performing actions on admins, etc
 
     Usage:
+        - client scope
         - executor is the user object of the user executing the moderation command
         - target is the user object of the user the moderation command is affecting
         - guild is the guild object of the guild the command is being executed in
     Returns:
         - boolean true if executor is higher
         - boolean false if executor is lower or equal
-        - boolean false if either user isn't in the guild
+        - boolean false if no guild
 **/
 
-const func = async (executor, target, guild = null) => {
+const func = async (client, executor, target, guild = null) => {
   if (guild) {
-    const executorMember = await guild.fetchMember(executor);
-    const targetMember = await guild.fetchMember(target);
+    const executorMember = await guild.fetchMember(await client.fetchUser(executor.id));
+    const targetMember = await guild.fetchMember(await client.fetchUser(target.id));
 
     return executorMember.highestRole.position > targetMember.highestRole.position;
   }
+
   return false;
 };
 


### PR DESCRIPTION
For moderation commands; Function to compare a command's executor to its target and return whether or not they're higher up the role hierarchy. (ie: moderators shouldn't be able to act on admins)